### PR TITLE
Update from cookiecutter template (2026-07-11)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ jobs:
                 label: Build image
                 command: make build
     # This seemed to shave 5ish% of the build time off when added
-    resource_class: large
+    resource_class: large.gen2
 
 workflows:
   version: 2

--- a/.cursor/rules/pr-review-threads.mdc
+++ b/.cursor/rules/pr-review-threads.mdc
@@ -1,0 +1,26 @@
+---
+description: When babysitting PRs — reply to review comments; do not resolve threads unless feedback was straightforward and fully applied
+alwaysApply: false
+---
+
+# PR review threads
+
+When triaging pull request review comments:
+
+- **Reply** to every unresolved thread with what you did, what you could not do, or why you disagree.
+- **Do not resolve** a review thread unless **all** of these are true:
+  1. The feedback was straightforward (not a design question, not "explain why", not "show me").
+  2. You fully agreed with it.
+  3. You applied it exactly as requested — no substitute approach the reviewer rejected.
+  4. You are very confident the author will agree the thread is done without further discussion.
+
+When in doubt, leave the thread **open** for the reviewer to resolve.
+
+Examples — **do not resolve**:
+- "Explain why this changed?" — answer in a reply; thread stays open.
+- "Not acceptable substitution" — even after reverting, wait for reviewer ack.
+- "Show me log of crash" — post the log; thread stays open.
+- You applied a workaround the reviewer might reject (file excludes vs repo-wide disable vs syntax change).
+
+Examples — **ok to resolve** (rare):
+- Typo fix they pointed at, you fixed exactly that typo, no ambiguity.

--- a/.cursor/rules/worktree-env-local-probe.mdc
+++ b/.cursor/rules/worktree-env-local-probe.mdc
@@ -1,0 +1,31 @@
+---
+description: >-
+  Cursor worktree bootstrap failed or env.local/op run debugging — read
+  file-based probe logs before inferring from missing direnv stderr
+alwaysApply: false
+globs:
+  - .envrc
+  - bin/probe_env_local
+  - config/env.local
+---
+
+# env.local probe logs (worktree bootstrap)
+
+`ls`/`cat` redirected to stderr in `.envrc` do **not** appear in worktree-fix bootstrap logs. Use file probes instead.
+
+## Before diagnosing bootstrap
+
+1. Read the pointer: `.env-local-probe-path` (one line: absolute log path).
+2. Read the log tail: `~/.cache/env-local-probe/<worktree-basename>.log` (e.g. `kaa0.log`).
+3. If missing or stale, run from repo root: `./bin/probe_env_local` (no direnv required).
+
+## Interpret `which_branch`
+
+| Value | Meaning |
+|-------|---------|
+| `env.local` | Symlink or readable mount present; `.envrc` should skip `op run`. |
+| `op_run` | No symlink/readable mount at eval time; falls back to `op run`. |
+
+Also check: `-L`/`-r`, `cat exit=` (124 = FIFO with no writer / Environment not mounted), `op_run_fallback` section.
+
+Every `.envrc` eval appends a block (source=`envrc`). Bootstrap retries produce multiple timestamped blocks — compare hook time to latest block.

--- a/.envrc
+++ b/.envrc
@@ -5,7 +5,13 @@
 
 PATH_add bin
 
-if [[ -r config/env.local ]]; then
+# File probe: bootstrap hooks omit .envrc stderr; see bin/probe_env_local and
+# ~/.cache/env-local-probe/<worktree-basename>.log (also .env-local-probe-path).
+ENV_LOCAL_PROBE_SOURCE=envrc ENV_LOCAL_PROBE_QUIET=1 ./bin/probe_env_local || true
+
+# -L: worktree symlink to mounted env.local (FIFO; -r is false without a writer).
+# -r: regular file or FIFO with an active reader/writer.
+if [[ -L config/env.local || -r config/env.local ]]; then
   # Load from mounted Environment file (empty mount => no secrets).
   if grep -qE '^[A-Z][A-Z0-9_]*=.*op://' config/env.local 2>/dev/null; then
     echo "config/env.local must contain resolved values, not op:// references." >&2
@@ -27,7 +33,8 @@ if [[ -r config/env.local ]]; then
       end
     '
   )"
-elif [[ -r config/env.1p ]] && grep -qE '^[A-Z][A-Z0-9_]*=' config/env.1p 2>/dev/null; then
+elif resolved_env_1p="$(./bin/resolve_env_1p)" && [[ -r "${resolved_env_1p}" ]] && grep -qE '^[A-Z][A-Z0-9_]*=' "${resolved_env_1p}" 2>/dev/null; then
   # Resolve op:// template when env.local is not mounted.
-  direnv_load op run --cache --env-file=config/env.1p -- direnv dump
+  ENV_1P="${resolved_env_1p}"
+  direnv_load op run --cache --env-file="${ENV_1P}" -- direnv dump
 fi

--- a/.git-hooks/bootstrap_local_overcommit.rb
+++ b/.git-hooks/bootstrap_local_overcommit.rb
@@ -1,0 +1,51 @@
+# typed: true
+# frozen_string_literal: true
+
+# Link machine-local Overcommit config across git worktrees and defer signature
+# verification until `overcommit --sign` has run in this worktree (via fix.sh).
+require 'yaml'
+require 'fileutils'
+
+# @param path [String]
+# @return [Hash, nil]
+def load_local_overcommit_config(path)
+  data = YAML.load_file(path)
+  data.is_a?(Hash) ? data : nil
+rescue StandardError
+  nil
+end
+
+# @param repo_root [String]
+# @return [String, nil]
+def sibling_worktree_local_overcommit(repo_root)
+  String(`git worktree list --porcelain 2>/dev/null`).each_line do |line|
+    next unless line.start_with?('worktree ')
+
+    worktree = line.delete_prefix('worktree ').strip
+    next if worktree == repo_root
+
+    candidate = File.join(worktree, '.local-overcommit.yml')
+    return candidate if File.exist?(candidate)
+  end
+  nil
+end
+
+repo_root = String(`git rev-parse --show-toplevel 2>/dev/null`).strip
+exit if repo_root.empty?
+
+local_file = File.join(repo_root, '.local-overcommit.yml')
+
+unless File.exist?(local_file)
+  source = sibling_worktree_local_overcommit(repo_root)
+  # @sg-ignore FileUtils.ln_sf
+  FileUtils.ln_sf(source, local_file) if source
+end
+
+return unless File.exist?(local_file)
+
+raw_config = load_local_overcommit_config(local_file)
+return unless raw_config&.[]('verify_signatures') == false
+
+signed = String(`git config --local --get overcommit.configuration.verifysignatures 2>/dev/null`).strip
+# @sg-ignore Unresolved call to []= on RBS::Unnamed::ENVClass
+ENV['OVERCOMMIT_NO_VERIFY'] = '1' if signed != '0'

--- a/.gitignore
+++ b/.gitignore
@@ -59,9 +59,11 @@ types.installed
 /config/env.local
 
 # Overcommit installs hooks here; only bootstrap post-checkout is tracked
+.local-overcommit.yml
 .githooks/*
 !.githooks/post-checkout
 
 # Ignore make target files
 /.make/*
 !/.make/.keep
+.env-local-probe-path

--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -73,6 +73,10 @@ PreCommit:
     problem_on_unmodified_line: warn
     quiet: false
 
+PostCheckout:
+  BundleInstall:
+    enabled: true
+
 PostCommit:
   BundleInstall:
     enabled: true
@@ -84,12 +88,6 @@ PostMerge:
 PostRewrite:
   BundleInstall:
     enabled: true
-
-PrePush:
-  CustomScript:
-    enabled: true
-    requires_files: false
-    required_executable: 'bin/git-push-validate'
 
 #PostCheckout:
 #  ALL: # Special hook name that customizes all hooks of this type

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,7 +43,7 @@ DEPENDENCIES
   punchlist (>= 1.3.1)
 
 CHECKSUMS
-  bundler (4.0.15) sha256=a4ceb882fe94a0e0ac63cd0813932bbfd631a14e5ac0b7975189b19a4d28d9e7
+  bundler (4.0.16) sha256=d6ca5dd440c24f9abce9844cf44cc8e18c6a553de65a47efb4544137af92c47d
   chef-utils (19.3.15) sha256=1c537a9c85b55b6d897de8e8af6b66b017a6dfae2b5e7b25e0bf320637e0b86a
   childprocess (5.1.0) sha256=9a8d484be2fd4096a0e90a0cd3e449a05bc3aa33f8ac9e4d6dcef6ac1455b6ec
   concurrent-ruby (1.3.7) sha256=4412caec3a5ea2e5fdc52076724c071a81f2c0593d83b2ac8cbb8ca63b3151b0
@@ -62,4 +62,4 @@ CHECKSUMS
   tomlrb (2.0.4) sha256=262f77947ac3ac9b3366a0a5940ecd238300c553e2e14f22009e2afcd2181b99
 
 BUNDLED WITH
-  4.0.15
+  4.0.16

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,7 +43,7 @@ DEPENDENCIES
   punchlist (>= 1.3.1)
 
 CHECKSUMS
-  bundler (4.0.13) sha256=19f08be7f27022cf0b89f27da0b044ae075e8270a9ef44ad248a932614e1ca3b
+  bundler (4.0.15) sha256=a4ceb882fe94a0e0ac63cd0813932bbfd631a14e5ac0b7975189b19a4d28d9e7
   chef-utils (19.3.15) sha256=1c537a9c85b55b6d897de8e8af6b66b017a6dfae2b5e7b25e0bf320637e0b86a
   childprocess (5.1.0) sha256=9a8d484be2fd4096a0e90a0cd3e449a05bc3aa33f8ac9e4d6dcef6ac1455b6ec
   concurrent-ruby (1.3.7) sha256=4412caec3a5ea2e5fdc52076724c071a81f2c0593d83b2ac8cbb8ca63b3151b0
@@ -62,4 +62,4 @@ CHECKSUMS
   tomlrb (2.0.4) sha256=262f77947ac3ac9b3366a0a5940ecd238300c553e2e14f22009e2afcd2181b99
 
 BUNDLED WITH
-  4.0.13
+  4.0.15

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-deps build-typecheck bundle_install cicoverage citypecheck citest citypecoverage clean clean-coverage clean-typecheck clean-typecoverage coverage default gem_dependencies help overcommit quality repl report-coverage report-coverage-to-codecov test typecheck typecoverage update_from_cookiecutter docs
+.PHONY: build build-deps build-typecheck bundle_install cicoverage citypecheck citest citypecoverage clean clean-coverage clean-typecheck clean-typecoverage coverage default gem_dependencies help overcommit quality repl report-coverage report-coverage-to-codecov test typecheck typecoverage post_cookiecutter_sync update_from_cookiecutter docs
 .DEFAULT_GOAL := default
 
 define PRINT_HELP_PYSCRIPT
@@ -87,7 +87,7 @@ gem_dependencies: .bundle/config
 Gemfile.lock.installed: Gemfile vendor/.keep
 	touch Gemfile.lock.installed
 
-vendor/.keep: Gemfile.lock
+vendor/.keep: Gemfile.lock .ruby-version
 	make gem_dependencies
 	bundle install
 	touch vendor/.keep
@@ -135,3 +135,7 @@ cicoverage: citest report-coverage-to-codecov ## check code coverage
 
 update_from_cookiecutter: ## Bring in changes from template project used to create this repo
 	bin/cookiecutter_project_upgrader.sh
+	@$(MAKE) post_cookiecutter_sync
+
+post_cookiecutter_sync: ## Ecosystem-specific steps after template sync (empty by default)
+	@:

--- a/bin/cookiecutter_project_upgrader.sh
+++ b/bin/cookiecutter_project_upgrader.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Run cookiecutter_project_upgrader and the update_from_cookiecutter finish phase.
 # Handles linked git worktrees (gitdir: .git pointer) and worktree-safe git branch ops.
+# Ecosystem-specific post-sync steps belong in Makefile post_cookiecutter_sync.
 
 set -euo pipefail
 
@@ -10,11 +11,35 @@ cookiecutter_project_upgrader --help >/dev/null
 MAIN_REPO_ROOT="$(dirname "$(git rev-parse --git-common-dir)")"
 GIT_DIR_PATH="$(git rev-parse --git-dir)"
 MAKE_DIR=".make"
-RBS_HIDDEN=0
-RUBOCOP_MAIN_HIDDEN=0
-RUBOCOP_CWD_HIDDEN=0
+TEMPLATE_BRANCH="${COOKIECUTTER_TEMPLATE_BRANCH:-cookiecutter-template}"
+TEMPLATE_UPGRADE_BRANCH="${COOKIECUTTER_TEMPLATE_UPGRADE_BRANCH:-main}"
 GIT_WORKTREE_SHIM=0
 REPO_CWD="$(pwd)"
+HIDDEN_BACKUPS=()
+HIDDEN_BACKUP_COUNT=0
+
+hide_for_bake() {
+  local src=$1 bak=$2
+  if [ -f "${src}" ]; then
+    mv "${src}" "${bak}"
+    HIDDEN_BACKUPS+=("${bak}|${src}")
+    HIDDEN_BACKUP_COUNT=$((HIDDEN_BACKUP_COUNT + 1))
+  fi
+}
+
+restore_hidden() {
+  local entry bak dest
+  if [ "${HIDDEN_BACKUP_COUNT}" -eq 0 ]; then
+    return 0
+  fi
+  for entry in "${HIDDEN_BACKUPS[@]}"; do
+    bak="${entry%%|*}"
+    dest="${entry#*|}"
+    [ -f "${bak}" ] && mv "${bak}" "${dest}"
+  done
+  HIDDEN_BACKUPS=()
+  HIDDEN_BACKUP_COUNT=0
+}
 
 cleanup_prepare() {
   if [ "${GIT_WORKTREE_SHIM}" -eq 1 ] && [ -f "${MAKE_DIR}/git-worktree-pointer" ]; then
@@ -22,55 +47,49 @@ cleanup_prepare() {
     mv "${MAKE_DIR}/git-worktree-pointer" .git
     GIT_WORKTREE_SHIM=0
   fi
-  if [ "${RBS_HIDDEN}" -eq 1 ] && [ -f "${MAKE_DIR}/rbs_collection.yaml.bak" ]; then
-    mv "${MAKE_DIR}/rbs_collection.yaml.bak" "${MAIN_REPO_ROOT}/rbs_collection.yaml"
-    rm -f "${MAKE_DIR}/rbs_collection_yaml_hidden"
-    RBS_HIDDEN=0
-  fi
-  if [ "${RUBOCOP_MAIN_HIDDEN}" -eq 1 ] && [ -f "${MAKE_DIR}/rubocop-main.yml.bak" ]; then
-    mv "${MAKE_DIR}/rubocop-main.yml.bak" "${MAIN_REPO_ROOT}/.rubocop.yml"
-    rm -f "${MAKE_DIR}/rubocop_main_hidden"
-    RUBOCOP_MAIN_HIDDEN=0
-  fi
-  if [ "${RUBOCOP_CWD_HIDDEN}" -eq 1 ] && [ -f "${MAKE_DIR}/rubocop-cwd.yml.bak" ]; then
-    mv "${MAKE_DIR}/rubocop-cwd.yml.bak" "${REPO_CWD}/.rubocop.yml"
-    rm -f "${MAKE_DIR}/rubocop_cwd_hidden"
-    RUBOCOP_CWD_HIDDEN=0
-  fi
-  if [ -d "${GIT_DIR_PATH}/cookiecutter" ]; then
-    rm -rf "${GIT_DIR_PATH}/cookiecutter"
-  fi
+  restore_hidden
+  [ -d "${GIT_DIR_PATH}/cookiecutter" ] && rm -rf "${GIT_DIR_PATH}/cookiecutter"
 }
 
 trap cleanup_prepare EXIT
 
 mkdir -p "${MAKE_DIR}"
 
+CONTEXT_FILE="${MAKE_DIR}/cookiecutter_context.json"
+TEMPLATE_URL=""
 if [ -f docs/cookiecutter_input.json ]; then
   jq 'del(._output_dir, ._repo_dir, ._checkout)' docs/cookiecutter_input.json \
-    > "${MAKE_DIR}/cookiecutter_context.json"
+    > "${CONTEXT_FILE}"
+  TEMPLATE_URL="$(jq -r '._template // empty' "${CONTEXT_FILE}")"
 fi
 
-if [ -f "${MAIN_REPO_ROOT}/rbs_collection.yaml" ]; then
-  mv "${MAIN_REPO_ROOT}/rbs_collection.yaml" "${MAKE_DIR}/rbs_collection.yaml.bak"
-  touch "${MAKE_DIR}/rbs_collection_yaml_hidden"
-  RBS_HIDDEN=1
-fi
-if [ -f "${MAIN_REPO_ROOT}/.rubocop.yml" ]; then
-  mv "${MAIN_REPO_ROOT}/.rubocop.yml" "${MAKE_DIR}/rubocop-main.yml.bak"
-  touch "${MAKE_DIR}/rubocop_main_hidden"
-  RUBOCOP_MAIN_HIDDEN=1
-fi
-# Nested tiers may have their own .rubocop.yml; hide it so RuboCop does not inherit
-# mismatched config while cookiecutter_project_upgrader runs under .git/cookiecutter/
-if [ -f "${REPO_CWD}/.rubocop.yml" ]; then
-  mv "${REPO_CWD}/.rubocop.yml" "${MAKE_DIR}/rubocop-cwd.yml.bak"
-  touch "${MAKE_DIR}/rubocop_cwd_hidden"
-  RUBOCOP_CWD_HIDDEN=1
-fi
+cookiecutter_cache_dir() {
+  local url=$1 name=""
+  if [[ "${url}" =~ github\.com[:/][^/]+/([^/.]+) ]]; then
+    name="${BASH_REMATCH[1]}"
+  elif [[ "${url}" =~ ^git@github\.com:[^/]+/([^/.]+) ]]; then
+    name="${BASH_REMATCH[1]}"
+  else
+    return 1
+  fi
+  printf '%s\n' "${HOME}/.cookiecutters/${name}"
+}
 
-if [ -f .make/git-worktree-pointer ] && [ ! -f .git ] && [ ! -L .git ]; then
-  echo "error: stale ${MAKE_DIR}/git-worktree-pointer but .git is missing; restore manually" >&2
+wipe_template_cache() {
+  local url=$1 cache=""
+  cache="$(cookiecutter_cache_dir "${url}")" || return 0
+  if [ -e "${cache}" ]; then
+    echo "Removing cookiecutter cache ${cache}"
+    rm -rf "${cache}"
+  fi
+}
+
+hide_for_bake "${MAIN_REPO_ROOT}/rbs_collection.yaml" "${MAKE_DIR}/rbs_collection.yaml.bak"
+hide_for_bake "${MAIN_REPO_ROOT}/.rubocop.yml" "${MAKE_DIR}/rubocop-main.yml.bak"
+hide_for_bake "${REPO_CWD}/.rubocop.yml" "${MAKE_DIR}/rubocop-cwd.yml.bak"
+
+if [ -f .make/git-worktree-pointer ] && [ ! -e .git ]; then
+  echo "error: stale ${MAKE_DIR}/git-worktree-pointer but .git missing" >&2
   exit 1
 fi
 
@@ -84,30 +103,36 @@ elif [ -f .git ] && [ ! -L .git ]; then
   exit 1
 fi
 
+[ -n "${TEMPLATE_URL}" ] && wipe_template_cache "${TEMPLATE_URL}"
+
 export IN_COOKIECUTTER_PROJECT_UPGRADER=1
-if [ -f "${MAKE_DIR}/cookiecutter_context.json" ]; then
-  cookiecutter_project_upgrader -c "${MAKE_DIR}/cookiecutter_context.json" -p true
-else
-  cookiecutter_project_upgrader
+UPGRADER_ARGS=(-p true -u "${TEMPLATE_UPGRADE_BRANCH}")
+[ -f "${CONTEXT_FILE}" ] && UPGRADER_ARGS=(-c "${CONTEXT_FILE}" "${UPGRADER_ARGS[@]}")
+if ! cookiecutter_project_upgrader "${UPGRADER_ARGS[@]}"; then
+  if ! git rev-parse --verify "${TEMPLATE_BRANCH}" &>/dev/null; then
+    >&2 echo "error: upgrader failed and ${TEMPLATE_BRANCH} is missing"
+    exit 1
+  fi
+  echo "cookiecutter_project_upgrader reported no template diff"
 fi
 
 trap - EXIT
 cleanup_prepare
 
-# Finish phase (worktree-safe: no checkout of branches locked in other worktrees)
 DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
-if git symbolic-ref -q "refs/remotes/origin/HEAD" >/dev/null 2>&1; then
+if git symbolic-ref -q refs/remotes/origin/HEAD &>/dev/null; then
   DEFAULT_BRANCH="$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')"
 fi
 
-if ! git diff --quiet -- Makefile 2>/dev/null || ! git diff --cached --quiet -- Makefile 2>/dev/null; then
+if ! git diff --quiet -- Makefile 2>/dev/null \
+  || ! git diff --cached --quiet -- Makefile 2>/dev/null; then
   git stash push -m 'update_from_cookiecutter Makefile' -- Makefile
   touch "${MAKE_DIR}/cookiecutter_makefile_stashed"
 fi
 
-git push --no-verify origin cookiecutter-template || true
+git push --no-verify origin "${TEMPLATE_BRANCH}"
+git fetch origin "${DEFAULT_BRANCH}"
 
-git fetch "origin" "${DEFAULT_BRANCH}"
 UPDATE_BRANCH="update-from-cookiecutter-$(date +%Y-%m-%d-%H%M)"
 git switch -c "${UPDATE_BRANCH}" "origin/${DEFAULT_BRANCH}"
 echo "Created branch ${UPDATE_BRANCH} from origin/${DEFAULT_BRANCH}"
@@ -116,7 +141,7 @@ bin/overcommit --sign
 bin/overcommit --sign pre-commit
 bin/overcommit --sign pre-push
 
-git merge cookiecutter-template || true
+git merge "${TEMPLATE_BRANCH}"
 git checkout --ours Gemfile.lock || true
 
 if [ -f "${MAKE_DIR}/cookiecutter_makefile_stashed" ]; then
@@ -124,12 +149,12 @@ if [ -f "${MAKE_DIR}/cookiecutter_makefile_stashed" ]; then
   rm -f "${MAKE_DIR}/cookiecutter_makefile_stashed"
 fi
 
-bundle update --conservative json rexml || true
-( make build && git add Gemfile.lock ) || true
 bin/overcommit --install || true
 
-echo
-echo "Please resolve any merge conflicts below and push up a PR with:"
-echo
-echo '   gh pr create --title "Update from cookiecutter" --body "Automated PR to update from cookiecutter boilerplate"'
-echo
+cat <<'EOF'
+
+Please resolve any merge conflicts below and push up a PR with:
+
+   gh pr create --title "Update from upstream" --body "Automated PR to update from upstream boilerplate"
+
+EOF

--- a/bin/git-push-validate
+++ b/bin/git-push-validate
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -euo pipefail
-
-if [ -x "$HOME/bin/git-push-validate" ]; then
-    exec "$HOME/bin/git-push-validate" "$@"
-fi
-
-make

--- a/bin/install_package
+++ b/bin/install_package
@@ -7,7 +7,12 @@ homebrew_package=${1:?homebrew package}
 apt_package=${2:-${homebrew_package}}
 if [ "$(uname)" == "Darwin" ]
 then
-  HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_UPGRADE=1 brew install "${homebrew_package}"
+  # HOMEBREW_NO_INSTALL_UPGRADE makes `brew install` fail when the formula is
+  # already installed at an older version; skip install when it is present.
+  if ! brew list --formula "${homebrew_package}" >/dev/null 2>&1
+  then
+    HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_UPGRADE=1 brew install "${homebrew_package}"
+  fi
 elif type apt-get >/dev/null 2>&1
 then
   if ! dpkg -s "${apt_package}" >/dev/null

--- a/bin/probe_env_local
+++ b/bin/probe_env_local
@@ -1,0 +1,67 @@
+#!/bin/bash -eu
+
+set -o pipefail
+
+# Append config/env.local readiness evidence. Bootstrap hooks omit .envrc stderr;
+# this log survives direnv/worktree-fix capture gaps.
+
+probe_log_dir="${ENV_LOCAL_PROBE_DIR:-${HOME}/.cache/env-local-probe}"
+mkdir -p "${probe_log_dir}"
+
+probe_id="${ENV_LOCAL_PROBE_ID:-$(basename "${PWD}")}"
+log_file="${probe_log_dir}/${probe_id}.log"
+
+{
+  echo "=== $(date -u +%Y-%m-%dT%H:%M:%SZ) source=${ENV_LOCAL_PROBE_SOURCE:-manual} pwd=${PWD} ==="
+  echo "git_head=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)@$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
+  echo "symlink:"; ls -ld config/env.local 2>&1 || true
+  target="$(readlink config/env.local 2>/dev/null || true)"
+  echo "readlink=${target:-<none>}"
+  if [[ -n ${target} ]]; then
+    echo "target:"; ls -ld "${target}" 2>&1 || true
+  fi
+  echo "tests: -L=$([[ -L config/env.local ]] && echo yes || echo no) -r=$([[ -r config/env.local ]] && echo yes || echo no)"
+  echo "file(1):"; file config/env.local 2>&1 || true
+  if [[ -L config/env.local || -r config/env.local ]]; then
+    branch=env.local
+  else
+    branch=op_run
+  fi
+  echo "which_branch=${branch}"
+  echo "cat_sample (2s timeout, keys only):"
+  if command -v timeout >/dev/null 2>&1; then
+    set +e
+    timeout 2 cat config/env.local 2>&1 | head -20 | while IFS= read -r line; do
+      key="${line%%=*}"
+      if [[ ${key} == "${line}" ]]; then
+        echo "  ${line}"
+      else
+        echo "  ${key}=<redacted>"
+      fi
+    done
+    cat_status=${PIPESTATUS[0]}
+    set -e
+    echo "  cat exit=${cat_status} (124=timeout)"
+  else
+    echo "  (timeout command not available)"
+  fi
+  if [[ ${branch} == op_run ]]; then
+    echo "op_run_fallback:"
+    resolved="$(./bin/resolve_env_1p 2>/dev/null || echo config/env.1p)"
+    echo "  resolve_env_1p=${resolved}"
+    echo "  resolved_readable=$([[ -r ${resolved} ]] && echo yes || echo no)"
+    if command -v op >/dev/null 2>&1; then
+      echo "  op_account_list=$(op account list 2>&1 | head -3 | tr '\n' '; ' || true)"
+    else
+      echo "  op_account_list=op not in PATH"
+    fi
+  fi
+  echo
+} >>"${log_file}"
+
+printf '%s\n' "${log_file}" >"${PWD}/.env-local-probe-path" 2>/dev/null || true
+
+if [[ ${ENV_LOCAL_PROBE_QUIET:-} != 1 ]]; then
+  echo "${log_file}"
+  tail -30 "${log_file}"
+fi

--- a/bin/resolve_env_1p
+++ b/bin/resolve_env_1p
@@ -1,0 +1,24 @@
+#!/bin/bash -eu
+
+set -o pipefail
+
+# config/env.1p may be a symlink whose target is only valid from the primary worktree.
+# Resolve via the first worktree listed by git.
+
+if [[ -r config/env.1p ]]; then
+  echo config/env.1p
+  exit 0
+fi
+
+main_wt=$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / { print $2; exit }')
+if [[ -n ${main_wt} && -r ${main_wt}/config/env.1p ]]; then
+  link_dir=${main_wt}/config
+  target=$(readlink "${link_dir}/env.1p")
+  resolved=${link_dir}/${target}
+  if [[ -r ${resolved} ]]; then
+    echo "${resolved}"
+    exit 0
+  fi
+fi
+
+echo config/env.1p

--- a/docs/cookiecutter_input.json
+++ b/docs/cookiecutter_input.json
@@ -1,6 +1,6 @@
 {
-    "_checkout": null,
-    "_output_dir": "/Users/broz/src/docker-circleci-python/.git/cookiecutter",
+    "_checkout": "main",
+    "_output_dir": "/Users/broz/.cursor/worktrees/docker-circleci-python/cascade-docker-circleci-python-1783776963197/.git/cookiecutter",
     "_repo_dir": "/Users/broz/.cookiecutters/cookiecutter-docker-image",
     "_template": "https://github.com/apiology/cookiecutter-docker-image",
     "email": "vince@broz.cc",

--- a/fix.sh
+++ b/fix.sh
@@ -22,6 +22,23 @@ debug_timing
 
 set -o pipefail
 
+ensure_homebrew_path() {
+  if [ "$(uname)" != "Darwin" ]
+  then
+    return 0
+  fi
+
+  local prefix
+  for prefix in /opt/homebrew /usr/local
+  do
+    if [ -x "${prefix}/bin/brew" ]
+    then
+      export PATH="${prefix}/bin:${prefix}/sbin:${PATH}"
+      return 0
+    fi
+  done
+}
+
 install_rbenv() {
   if [ "$(uname)" == "Darwin" ]
   then
@@ -45,6 +62,7 @@ EOF
 }
 
 set_rbenv_env_variables() {
+  ensure_homebrew_path
   export PATH="${HOME}/.rbenv/bin:$PATH"
   eval "$(rbenv init -)"
 }
@@ -67,6 +85,8 @@ ensure_ruby_build() {
 }
 
 ensure_rbenv() {
+  ensure_homebrew_path
+
   if ! type rbenv >/dev/null 2>&1 && ! [ -f "${HOME}/.rbenv/bin/rbenv" ]
   then
     install_rbenv
@@ -188,6 +208,12 @@ ensure_bundle() {
       bundler_version=$(bundle --version | cut -d ' ' -f 3)
   fi
   echo "Bundler version: ${bundler_version}"
+  active_bundler_version=$(bundle --version 2>/dev/null | cut -d ' ' -f 3)
+  if [ -n "${bundler_version}" ] && [ "${bundler_version}" != "${active_bundler_version}" ]
+  then
+    gem install "bundler:${bundler_version}"
+    hash -r
+  fi
   bundler_version_major=$(cut -d. -f1 <<< "${bundler_version}")
   bundler_version_minor=$(cut -d. -f2 <<< "${bundler_version}")
   bundler_version_patch=$(cut -d. -f3 <<< "${bundler_version}")
@@ -279,23 +305,23 @@ set_pyenv_env_variables() {
   #
   # https://app.circleci.com/pipelines/github/apiology/cookiecutter-pypackage/15/workflows/10506069-7662-46bd-b915-2992db3f795b/jobs/15
   set +u
+  ensure_homebrew_path
   export PYENV_ROOT="${HOME}/.pyenv"
-  export PATH="${PYENV_ROOT}/bin:$PATH"
+  export PATH="${PYENV_ROOT}/bin:${PYENV_ROOT}/shims:${PATH}"
   eval "$(pyenv init --path)"
   eval "$(pyenv virtualenv-init -)"
   set -u
 }
 
 ensure_pyenv() {
+  ensure_homebrew_path
+
   if ! type pyenv >/dev/null 2>&1 && ! [ -f "${HOME}/.pyenv/bin/pyenv" ]
   then
     install_pyenv
   fi
 
-  if ! type pyenv >/dev/null 2>&1
-  then
-    set_pyenv_env_variables
-  fi
+  set_pyenv_env_variables
 }
 
 update_package() {
@@ -429,6 +455,34 @@ EOF
   chmod +x .githooks/post-checkout
 }
 
+patch_overcommit_hooks() {
+  # Inject bootstrap so Cursor worktrees inherit .local-overcommit.yml before
+  # Overcommit loads config (gitignored file is absent on fresh worktree checkout).
+  # Do NOT patch overcommit-hook: it must match the gem template or Overcommit
+  # self-update will reinstall all hooks and strip these patches.
+  local hook hooks_dir bootstrap_line
+  hooks_dir="$(git config --get core.hooksPath 2>/dev/null || echo .git/hooks)"
+  bootstrap_line="repo_root = String(\`git rev-parse --show-toplevel 2>/dev/null\`).strip; load File.join(repo_root, '.git-hooks', 'bootstrap_local_overcommit.rb') rescue nil if repo_root != '' # OVERCOMMIT_REPO_BOOTSTRAP"
+
+  for hook in "${hooks_dir}"/*
+  do
+    [ -f "$hook" ] || continue
+    [[ "$(basename "$hook")" == "overcommit-hook" ]] && continue
+    grep -q 'OVERCOMMIT_REPO_BOOTSTRAP' "$hook" && continue
+    grep -q 'Entrypoint for Overcommit hook integration' "$hook" || continue
+    ruby - "$hook" "$bootstrap_line" <<'RUBY'
+hook_path = ARGV[0]
+bootstrap_line = ARGV[1]
+contents = File.read(hook_path)
+marker = "if ENV['OVERCOMMIT_DISABLE'].to_i != 0 || ENV['OVERCOMMIT_DISABLED'].to_i != 0\n  exit\nend\n"
+unless contents.include?('OVERCOMMIT_REPO_BOOTSTRAP')
+  raise "bootstrap insertion point not found in #{hook_path}" unless contents.include?(marker)
+  File.write(hook_path, contents.sub(marker, "#{marker}\n#{bootstrap_line}\n"))
+end
+RUBY
+  done
+}
+
 ensure_overcommit() {
   # don't run if we're in the middle of a cookiecutter child project
   # test, or otherwise don't have a Git repo to install hooks into...
@@ -437,6 +491,7 @@ ensure_overcommit() {
     bundle exec overcommit --install
     bundle exec overcommit --sign
     bundle exec overcommit --sign pre-commit
+    patch_overcommit_hooks
     install_bootstrap_post_checkout_hook
   else
     >&2 echo 'Not in a git repo; not installing git hooks'


### PR DESCRIPTION
## Summary

Sync boilerplate from `cookiecutter-docker-image` into docker-circleci-python while preserving docker-specific Makefile targets (`build`, `publish`, `default: build test quality`) and the `docker-circleci-python-*` pyenv virtualenv name in `fix.sh`.

- **CI:** CircleCI `resource_class: large.gen2` for build job
- **Env/bootstrap:** `.envrc` worktree env.local probe (`-L` symlink), `bin/probe_env_local`, `bin/resolve_env_1p`; Overcommit worktree bootstrap (`.git-hooks/bootstrap_local_overcommit.rb`, `patch_overcommit_hooks` in `fix.sh`)
- **Overcommit:** `PostCheckout: BundleInstall`; remove deprecated `PrePush: git-push-validate` hook and delete `bin/git-push-validate`
- **Makefile:** cookiecutter upgrade targets; use `bin/overcommit --run`
- **Misc:** `bin/install_package` skip brew install when formula already present; bundler 4.0.16 lockfile bump

## Risks

- Removing `bin/git-push-validate` / PrePush hook drops local `make` gate before push (intentional upstream change)
- `docs/cookiecutter_input.json` records this upgrade run metadata

## Test plan

- [ ] CircleCI build + test workflow green
- [ ] `make build` produces docker image
- [ ] `make quality` / overcommit hooks pass
- [ ] `./fix.sh` completes on fresh worktree checkout